### PR TITLE
array to string conversion fix for PHP7 in BugsnagLogTarget

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pinfirestudios/yii2-bugsnag",
+    "name": "jeffwalsh/yii2-bugsnag",
     "description": "Yii2 log target and ErrorHandler for BugSnag",
     "keywords": ["logging", "errors"],
     "license": "MIT",

--- a/src/BugsnagLogTarget.php
+++ b/src/BugsnagLogTarget.php
@@ -70,9 +70,9 @@ class BugsnagLogTarget extends \yii\log\Target
             function($message) use ($levelMap)
             {
                 list($message, $level, $category, $timestamp) = $message; 
-
+                $levelMapLevel = $levelMap[$level];
                 $date = date('Y-m-d H:i:s', $timestamp) . '.' . substr(fmod($timestamp, 1), 2, 4);
-                return "{$levelMap[$level]} - ({$category}) @ {$date} - {$message}";
+                return "{$levelMapLevel} - ({$category}) @ {$date} - {$message}";
             }, 
             self::$exportedMessages, 
             isset(self::$instance) ? self::$instance->messages : [] 


### PR DESCRIPTION
Was throwing multiple array to string conversions in PHP7 due to the {$levelMap[$level]} syntax in the string.